### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19",
-        "sanity": "^3",
+        "sanity": "^3 || ^4.0.0-0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19",
-    "sanity": "^3",
+    "sanity": "^3 || ^4.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```
Progress: resolved 1030, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ @sanity/sanity-plugin-async-list 1.3.1
  └── ✕ unmet peer sanity@^3: found 4.0.0-0
Done in 9.4s using pnpm v10.12.1

```
This fixes it.

### Testing

Tested locally